### PR TITLE
provisional workaround for issue #16 on Windows

### DIFF
--- a/prebuild.py
+++ b/prebuild.py
@@ -2,14 +2,18 @@
 
 import os
 import os.path
+import shutil
 
 example_lib_dir = "examples/espcamlib"
 dst = "examples/espcamlib/src"
 src = "../../src"
+lib = "src"
 
 os.makedirs(example_lib_dir, 0o755, True)
 
 if not os.path.exists(dst) and os.name != 'nt':
     os.symlink(src, dst)
     print("Symbolic link created successfully")
-
+elif os.name == 'nt':
+    shutil.copytree(lib, dst)
+    print("Source lib for examples created successfully")


### PR DESCRIPTION
Provisional workaround for issue #16 on Windows.  It uses copy command instead create symlinks, because in Windows it will needs special permissions. 